### PR TITLE
Add inline extensions to some methods to avoid nxxm duplicate symbol link error

### DIFF
--- a/xxhr/impl/session-beast.hpp
+++ b/xxhr/impl/session-beast.hpp
@@ -42,49 +42,49 @@ namespace xxhr {
 
   using plain_or_tls = std::variant<std::monostate, tcp::socket, ssl::stream<tcp::socket>>;
 
-  
+
 
   class Session::Impl : public std::enable_shared_from_this<Session::Impl> {
     public:
     Impl() {
           }
 
-    void SetUrl(const Url& url);
-    void SetParameters(const Parameters& parameters);
-    void SetParameters(Parameters&& parameters);
-    void SetHeader(const Header& header);
-    void SetTimeout(const Timeout& timeout);
-    void SetAuth(const Authentication& auth);
-    void SetDigest(const Digest& auth);
+    inline void SetUrl(const Url& url);
+    inline void SetParameters(const Parameters& parameters);
+    inline void SetParameters(Parameters&& parameters);
+    inline void SetHeader(const Header& header);
+    inline void SetTimeout(const Timeout& timeout);
+    inline void SetAuth(const Authentication& auth);
+    inline void SetDigest(const Digest& auth);
 
-    void SetMultipart(Multipart&& multipart);
-    void SetMultipart(const Multipart& multipart);
-    void SetRedirect(const bool& redirect);
-    void SetMaxRedirects(const MaxRedirects& max_redirects);
-    void SetCookies(const Cookies& cookies, bool delete_them = false);
-    void CookiesCleanup();
+    inline void SetMultipart(Multipart&& multipart);
+    inline void SetMultipart(const Multipart& multipart);
+    inline void SetRedirect(const bool& redirect);
+    inline void SetMaxRedirects(const MaxRedirects& max_redirects);
+    inline void SetCookies(const Cookies& cookies, bool delete_them = false);
+    inline void CookiesCleanup();
 
     //! Set the provided body of request
-    void SetBody(const Body& body);
+    inline void SetBody(const Body& body);
 
     template<class Handler>
-    void SetHandler(const on_response_<Handler>&& functor) {
+    inline void SetHandler(const on_response_<Handler>&& functor) {
       on_response = functor;
     }
 
-    void QUERY(http::verb method);
+    inline void QUERY(http::verb method);
 
-    void DELETE_();
-    void GET();
-    void HEAD();
-    void OPTIONS();
-    void PATCH();
-    void POST();
-    void PUT();
+    inline void DELETE_();
+    inline void GET();
+    inline void HEAD();
+    inline void OPTIONS();
+    inline void PATCH();
+    inline void POST();
+    inline void PUT();
 
   private:
-    void full_request(http::verb method);
-    void do_one_request(http::verb method);
+    inline void full_request(http::verb method);
+    inline void do_one_request(http::verb method);
 
     util::url_parts url_parts_;
     std::string url_;
@@ -102,7 +102,7 @@ namespace xxhr {
     boost::asio::steady_timer timeouter_for_graceful_shutdown{ioc};
     ssl::context ctx{ssl::context::sslv23_client};
     tcp::resolver resolver_{ioc};
-    plain_or_tls stream_; 
+    plain_or_tls stream_;
     boost::beast::flat_buffer buffer_; // (Must persist between reads)
 
     std::shared_ptr<http::response_parser<http::string_body>> res_parser_ = std::make_shared<http::response_parser<http::string_body>>();
@@ -119,7 +119,7 @@ namespace xxhr {
       return std::get<tcp::socket>(stream_);
     }
 
-    void fail(boost::system::error_code ec, xxhr::ErrorCode xxhr_ec) { 
+    void fail(boost::system::error_code ec, xxhr::ErrorCode xxhr_ec) {
       //TODO: if (trace)
       std::cerr << ec << ": " << ec.message() << " distilled into : " << uint32_t(xxhr_ec) << "\n";
 
@@ -226,7 +226,7 @@ namespace xxhr {
 
         if(ec)
           return fail(ec, ErrorCode::NETWORK_SEND_FAILURE);
-        
+
         // Receive the HTTP response
         std::visit([this](auto& stream) {
           if constexpr (std::is_same_v<std::monostate,std::decay_t<decltype(stream)>>) return;
@@ -313,7 +313,7 @@ namespace xxhr {
 
     void on_too_long_async_shutdown(boost::system::error_code ec) {
       if (ec != boost::asio::error::operation_aborted) {
-    
+
         ioc.stop();
 
         tcp::socket* socket;
@@ -344,7 +344,7 @@ namespace xxhr {
 
     void on_timeout(const boost::system::error_code& ec) {
       if (ec != boost::asio::error::operation_aborted) {
-        
+
         ioc.stop();
 
         tcp::socket* socket;
@@ -366,8 +366,8 @@ namespace xxhr {
   };
 
   void Session::Impl::SetUrl(const Url& url) {
-    url_ = url; 
-    url_parts_ = util::parse_url(url); 
+    url_ = url;
+    url_parts_ = util::parse_url(url);
   }
   void Session::Impl::SetParameters(Parameters&& parameters) {
     parameters_ = std::move(parameters);
@@ -411,20 +411,20 @@ namespace xxhr {
 
     for (auto it = multipart.parts.begin(); it != multipart.parts.end(); ++it) {
       auto& part = *it;
-      
+
       body << boundary_delim << boundary_str << CRLF;
 
       body << "Content-Disposition: form-data; name=\"" << part.name << "\"; " << "filename=\"" << part.value << "\"" << CRLF
-       << "Content-Type: application/octet-stream" 
+       << "Content-Type: application/octet-stream"
        << CRLF
-       << CRLF;      
+       << CRLF;
 
       if (part.is_file) {
-        std::ifstream ifs(part.value, std::ios::in | std::ios::binary); 
+        std::ifstream ifs(part.value, std::ios::in | std::ios::binary);
         ifs.exceptions(std::ios::badbit);
 
         ifs.seekg(0, ifs.end);
-        auto file_size = ifs.tellg(); 
+        auto file_size = ifs.tellg();
         ifs.seekg(0, ifs.beg);
 
         std::string file_content(file_size, std::string::value_type{});
@@ -464,9 +464,9 @@ namespace xxhr {
 
   void Session::Impl::SetCookies(const Cookies& cookies, bool delete_them) {
     for (auto cookie : cookies.all()) {
-      auto cookie_string = 
+      auto cookie_string =
         xxhr::util::urlEncode(cookie.first)
-        + "=" + 
+        + "=" +
         xxhr::util::urlEncode(cookie.second);
 
       req_.set(http::field::set_cookie, cookie_string);
@@ -474,14 +474,14 @@ namespace xxhr {
 
   }
 
-  void Session::Impl::SetBody(const Body& body) { 
+  void Session::Impl::SetBody(const Body& body) {
 
     if (body.is_form_encoded) {
       req_.set(http::field::content_type, "application/x-www-form-urlencoded");
     }
 
-    req_.body() = body.content; 
-  
+    req_.body() = body.content;
+
   }
 
 
@@ -493,7 +493,7 @@ namespace xxhr {
     // We need to download whatever fits in RAM
     res_parser_->body_limit(std::numeric_limits<std::uint64_t>::max());
     //TODO: change the limit for uploading too
-    
+
 
 
     req_.method(method);
@@ -518,16 +518,16 @@ namespace xxhr {
 
     if (timeout_ != std::chrono::milliseconds(0)) {
       timeouter.expires_after(timeout_);
-      timeouter.async_wait(std::bind(&Session::Impl::on_timeout, shared_from_this(), std::placeholders::_1)); 
+      timeouter.async_wait(std::bind(&Session::Impl::on_timeout, shared_from_this(), std::placeholders::_1));
     }
 
   }
 
   void Session::Impl::full_request(http::verb verb) {
-    do { 
-      ioc.reset(); 
-      do_one_request(verb); 
-      ioc.run(); 
+    do {
+      ioc.reset();
+      do_one_request(verb);
+      ioc.run();
     } while (follow_next_redirect);
   }
 

--- a/xxhr/impl/session-emscripten.hpp
+++ b/xxhr/impl/session-emscripten.hpp
@@ -34,38 +34,38 @@ namespace xxhr {
 
     public:
 
-    void SetUrl(const Url& url);
-    void SetParameters(const Parameters& parameters);
-    void SetParameters(Parameters&& parameters);
-    void SetHeader(const Header& header);
-    void SetTimeout(const Timeout& timeout);
-    void SetAuth(const Authentication& auth);
-    void SetDigest(const Digest& auth);
+    inline void SetUrl(const Url& url);
+    inline void SetParameters(const Parameters& parameters);
+    inline void SetParameters(Parameters&& parameters);
+    inline void SetHeader(const Header& header);
+    inline void SetTimeout(const Timeout& timeout);
+    inline void SetAuth(const Authentication& auth);
+    inline void SetDigest(const Digest& auth);
 
-    void SetMultipart(Multipart&& multipart);
-    void SetMultipart(const Multipart& multipart);
-    void SetRedirect(const bool& redirect);
-    void SetMaxRedirects(const MaxRedirects& max_redirects);
-    void SetCookies(const Cookies& cookies, bool delete_them = false);
-    void CookiesCleanup();
+    inline void SetMultipart(Multipart&& multipart);
+    inline void SetMultipart(const Multipart& multipart);
+    inline void SetRedirect(const bool& redirect);
+    inline void SetMaxRedirects(const MaxRedirects& max_redirects);
+    inline void SetCookies(const Cookies& cookies, bool delete_them = false);
+    inline void CookiesCleanup();
 
     //! Set the provided body
-    void SetBody(const Body& body);
+    inline void SetBody(const Body& body);
 
     template<class Handler>
-    void SetHandler(const on_response_<Handler>&& functor) {
+    inline void SetHandler(const on_response_<Handler>&& functor) {
       on_response = functor;
     }
 
-    void QUERY(const std::string& method);
+    inline void QUERY(const std::string& method);
 
-    void DELETE_();
-    void GET();
-    void HEAD();
-    void OPTIONS();
-    void PATCH();
-    void POST();
-    void PUT();
+    inline void DELETE_();
+    inline void GET();
+    inline void HEAD();
+    inline void OPTIONS();
+    inline void PATCH();
+    inline void POST();
+    inline void PUT();
 
     enum ReadyState {
       UNSENT = 0, // 	Client has been created. open() not called yet.
@@ -75,7 +75,7 @@ namespace xxhr {
       DONE
     };
 
-    void on_readystate(val event) {
+    inline void on_readystate(val event) {
       //std::cout << "xxhr::on_readystate: " <<  xhr["statusText"].as<std::string>() << " status : " << xhr["status"].as<size_t>() << std::endl;
 
       if (xhr["readyState"].as<size_t>() == DONE) {
@@ -91,7 +91,7 @@ namespace xxhr {
             Response{
               xhr["status"].as<size_t>(),
               (xhr["status"].as<size_t>() == 0) ?
-                  Error{ErrorCode::CONNECTION_FAILURE} 
+                  Error{ErrorCode::CONNECTION_FAILURE}
                 : Error{},
               xhr["responseText"].as<std::string>(),
               (!xhr.call<val>("getAllResponseHeaders").isNull()) ?
@@ -160,13 +160,13 @@ namespace xxhr {
 
   void Session::Impl::SetAuth(const Authentication& auth) {
     auth_ = auth;
-    //Some old browser might need this, instead of open with pwd : xhr.call<val>("setRequestHeader", 
+    //Some old browser might need this, instead of open with pwd : xhr.call<val>("setRequestHeader",
     //  "Authorization", std::string("Basic ") + util::encode64(auth.GetAuthString());
   }
 
   void Session::Impl::SetDigest(const Digest& auth) {
     auth_ = auth;
-    //Some old browser might need this, instead of open with pwd : xhr.call<val>("setRequestHeader", 
+    //Some old browser might need this, instead of open with pwd : xhr.call<val>("setRequestHeader",
     //  "Authorization", std::string("Basic ") + util::encode64(auth.GetAuthString());
   }
 
@@ -174,7 +174,7 @@ namespace xxhr {
     val formdata = val::global("FormData").new_();
 
     for (auto& part : multipart.parts) {
-      // https://developer.mozilla.org/fr/docs/Web/API/FormData 
+      // https://developer.mozilla.org/fr/docs/Web/API/FormData
       if (part.is_file) {
         throw std::runtime_error("File multipart was not yet implemented, would require 1h of work though");
         //XXX: Implement file, File cannot be instantiated normally, it should be forwarded from user input.
@@ -192,7 +192,7 @@ namespace xxhr {
         buf["size"] = val(part.value.size());
 
         formdata.call<val>("append", part.name, buf );
-      } 
+      }
 
       // TODO : Implement normal form text value for web platform
     }
@@ -202,7 +202,7 @@ namespace xxhr {
 
 
   void Session::Impl::SetRedirect(const bool& ) {
-    // TODO : Implement redirect with a switching backend, following support : 
+    // TODO : Implement redirect with a switching backend, following support :
     //  - Fetch API can handle redirection limitations
     //  - Fetch API is not yet supported on all browser
     //  - If not then throw or indicate with some error message and go back to xhr
@@ -210,7 +210,7 @@ namespace xxhr {
   }
 
   void Session::Impl::SetMaxRedirects(const MaxRedirects& ) {
-    // TODO : Implement redirect with a switching backend, following support : 
+    // TODO : Implement redirect with a switching backend, following support :
     //  - Fetch API can handle redirection limitations
     //  - Fetch API is not yet supported on all browser
     //  - If not then throw or indicate with some error message and go back to xhr
@@ -219,28 +219,28 @@ namespace xxhr {
 
   void Session::Impl::SetCookies(const Cookies& cookies, bool delete_them) {
     // XXX: Should we before we set any specified cookies, we have to remove ALL others ?
-    
+
     cookies_ = cookies;
     xhr["withCredentials"] = val(true);
 
     for (auto cookie : cookies.all()) {
-      auto cookie_string = 
+      auto cookie_string =
         xxhr::util::urlEncode(cookie.first)
-        + "=" + 
+        + "=" +
         xxhr::util::urlEncode(cookie.second);
 
-      if (delete_them) { 
-        cookie_string += "; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;"; 
+      if (delete_them) {
+        cookie_string += "; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
         // If someone finds this a good programming idiom he should go to hell
         // with all their browser developers friends. Instead of giving you
         // cookie.delete, we only have got the possibility to put a date in the
         // past... -_-'
-      } 
-      
-      // This [de]register the cookies, but if you just read cookie you 
+      }
+
+      // This [de]register the cookies, but if you just read cookie you
       // get the full list. -_-'
       auto document = val::global("document");
-      document["cookie"] = val(cookie_string); 
+      document["cookie"] = val(cookie_string);
     }
 
   }
@@ -248,13 +248,13 @@ namespace xxhr {
   //! After sending remove request specific cookies from global document
   void Session::Impl::CookiesCleanup() { SetCookies(cookies_, true); }
 
-  void Session::Impl::SetBody(const Body& body) { 
+  void Session::Impl::SetBody(const Body& body) {
 
     if (body.is_form_encoded) {
       xhr.call<val>("setRequestHeader", str("Content-type"), str("application/x-www-form-urlencoded"));
     }
 
-    body_ = body.content; 
+    body_ = body.content;
   }
 
   void Session::Impl::QUERY(const std::string& method) {
@@ -265,7 +265,7 @@ namespace xxhr {
     } else {
       xhr.call<val>("open", method, url_, true);
     }
-    
+
     for (auto item = headers.cbegin(); item != headers.cend(); ++item) {
       xhr.call<val>("setRequestHeader", item->first, item->second);
     }

--- a/xxhr/session.hpp
+++ b/xxhr/session.hpp
@@ -20,50 +20,50 @@ namespace xxhr {
 
 class Session {
   public:
-  Session();
-  ~Session();
+  inline Session();
+  inline ~Session();
 
-  void SetUrl(const Url& url);
-  void SetParameters(const Parameters& parameters);
-  void SetParameters(Parameters&& parameters);
-  void SetHeader(const Header& header);
-  void SetTimeout(const Timeout& timeout);
-  void SetAuth(const Authentication& auth);
-  void SetDigest(const Digest& auth);
-  void SetMultipart(Multipart&& multipart);
-  void SetMultipart(const Multipart& multipart);
-  void SetRedirect(const bool& redirect);
-  void SetMaxRedirects(const MaxRedirects& max_redirects);
-  void SetCookies(const Cookies& cookies);
-  void SetBody(Body&& body);
-  void SetBody(const Body& body);
+  inline void SetUrl(const Url& url);
+  inline void SetParameters(const Parameters& parameters);
+  inline void SetParameters(Parameters&& parameters);
+  inline void SetHeader(const Header& header);
+  inline void SetTimeout(const Timeout& timeout);
+  inline void SetAuth(const Authentication& auth);
+  inline void SetDigest(const Digest& auth);
+  inline void SetMultipart(Multipart&& multipart);
+  inline void SetMultipart(const Multipart& multipart);
+  inline void SetRedirect(const bool& redirect);
+  inline void SetMaxRedirects(const MaxRedirects& max_redirects);
+  inline void SetCookies(const Cookies& cookies);
+  inline void SetBody(Body&& body);
+  inline void SetBody(const Body& body);
 
   // Used in templated functions
-  void SetOption(const Url& url);
-  void SetOption(const Parameters& parameters);
-  void SetOption(Parameters&& parameters);
-  void SetOption(const Header& header);
-  void SetOption(const Timeout& timeout);
-  void SetOption(const Authentication& auth);
-  void SetOption(const Digest& auth);
-  void SetOption(Multipart&& multipart);
-  void SetOption(const Multipart& multipart);
-  void SetOption(const bool& redirect);
-  void SetOption(const MaxRedirects& max_redirects);
-  void SetOption(const Cookies& cookies);
-  void SetOption(Body&& body);
-  void SetOption(const Body& body);
+  inline void SetOption(const Url& url);
+  inline void SetOption(const Parameters& parameters);
+  inline void SetOption(Parameters&& parameters);
+  inline void SetOption(const Header& header);
+  inline void SetOption(const Timeout& timeout);
+  inline void SetOption(const Authentication& auth);
+  inline void SetOption(const Digest& auth);
+  inline void SetOption(Multipart&& multipart);
+  inline void SetOption(const Multipart& multipart);
+  inline void SetOption(const bool& redirect);
+  inline void SetOption(const MaxRedirects& max_redirects);
+  inline void SetOption(const Cookies& cookies);
+  inline void SetOption(Body&& body);
+  inline void SetOption(const Body& body);
 
   template<class Handler>
-  void SetOption(const on_response_<Handler>&& on_response);
+  inline void SetOption(const on_response_<Handler>&& on_response);
 
-  void DELETE_();
-  void GET();
-  void HEAD();
-  void OPTIONS();
-  void PATCH();
-  void POST();
-  void PUT();
+  inline void DELETE_();
+  inline void GET();
+  inline void HEAD();
+  inline void OPTIONS();
+  inline void PATCH();
+  inline void POST();
+  inline void PUT();
 
   class Impl;
   private:


### PR DESCRIPTION
From feature/fix-neverending-ssl-async-graceful-shutdown, add inline extensions to some methods to avoid nxxm duplicate symbol link error