### PR TITLE
Non standard headers

### DIFF
--- a/xxhr/impl/session-beast.hpp
+++ b/xxhr/impl/session-beast.hpp
@@ -382,7 +382,12 @@ namespace xxhr {
     for (auto&& entry : header) {
       auto& h = entry.first;
       auto& v = entry.second;
-      req_.set(boost::beast::http::string_to_field(h), v);
+      auto field = boost::beast::http::string_to_field(h);
+      if (field == boost::beast::http::field::unknown) {
+        req_.insert(h, v);
+      } else {
+        req_.set(field, v);
+      }
     }
   }
 


### PR DESCRIPTION
xxhr did only support standard http headers when used natively, it now forward unknown headers as passed in.