### PR TITLE
[base64] decoding input-buffers that have '\0' 

### DIFF
--- a/test/base64.cpp
+++ b/test/base64.cpp
@@ -1,0 +1,31 @@
+#define BOOST_TEST_MODULE base64
+#include <boost/test/included/unit_test.hpp>
+
+#include <xxhr/util.hpp>
+
+std::map<std::string, std::string> test_data {
+  { "", "" },
+  { "TQ=="         , "M" },
+  { "TWE="         , "Ma" },
+  { "TWFu"         , "Man" },
+  { "cGxlYXN1cmUu" , "pleasure." },
+  { "bGVhc3VyZS4=" , "leasure." },
+  { "ZWFzdXJlLg==" , "easure." },
+  { "YXN1cmUu"     , "asure." },
+  { "c3VyZS4="     , "sure." },
+  { "c3VyZS4="     , "sure." },
+  { "AQABAFEAAAD5AAAAAA==", { 0x01, 0x00, 0x01, 0x00 0x51 0x00, 0x00, 0x00, 0xf9, 0x00, 0x00, 0x00, 0x00 } }
+}; 
+
+
+BOOST_AUTO_TEST_CASE(decode) {
+  for (const auto& data : test_data) {
+    BOOST_REQUIRE_EQUAL(xxhr::util::decode64(data.first), data.second);
+  }
+} 
+
+BOOST_AUTO_TEST_CASE(encode) {
+  for (const auto& data : test_data) {
+    BOOST_REQUIRE_EQUAL(xxhr::util::encode64(data.second), data.first);
+  }
+} 

--- a/test/base64.cpp
+++ b/test/base64.cpp
@@ -14,18 +14,22 @@ std::map<std::string, std::string> test_data {
   { "YXN1cmUu"     , "asure." },
   { "c3VyZS4="     , "sure." },
   { "c3VyZS4="     , "sure." },
-  { "AQABAFEAAAD5AAAAAA==", { 0x01, 0x00, 0x01, 0x00 0x51 0x00, 0x00, 0x00, 0xf9, 0x00, 0x00, 0x00, 0x00 } }
+  { "AQABAFEAAAD5AAAAAA==", { 0x01, 0x00, 0x01, 0x00, 0x51, 0x00, 0x00, 0x00, char(0xf9), 0x00, 0x00, 0x00, 0x00 } }
 }; 
 
 
 BOOST_AUTO_TEST_CASE(decode) {
+  BOOST_REQUIRE(test_data.size() > 0);
   for (const auto& data : test_data) {
+    std::cout << data.first << " should be " << data.second << std::endl;
     BOOST_REQUIRE_EQUAL(xxhr::util::decode64(data.first), data.second);
   }
 } 
 
 BOOST_AUTO_TEST_CASE(encode) {
+  BOOST_REQUIRE(test_data.size() > 0);
   for (const auto& data : test_data) {
+    std::cout << data.first << " should be " << data.second << std::endl;
     BOOST_REQUIRE_EQUAL(xxhr::util::encode64(data.second), data.first);
   }
 } 

--- a/xxhr/util.hpp
+++ b/xxhr/util.hpp
@@ -168,10 +168,16 @@ namespace util {
   inline std::string decode64(const std::string &val) {
       using namespace boost::archive::iterators;
       using It = transform_width<binary_from_base64<std::string::const_iterator>, 8, 6>;
-      return boost::algorithm::trim_right_copy_if(std::string(It(std::begin(val)), It(std::end(val))), [](char c) {
-          return c == '\0';
-      });
+      // Remove padding and not all encoded \0  
+      // See https://svn.boost.org/trac10/ticket/5629#comment:9
+      auto decoded_with_padding_chars_as_nulls = std::string(It(std::begin(val)), It(std::end(val)));
+      auto padding_count = std::count(val.end()-((std::min)(2, val.size())), val.end());
+      auto decoded = decoded_with_padding_chars_as_nulls.resize(decoded_with_padding_chars_as_nulls.size()-decoded_with_padding_chars_as_nulls);
+      decoded_with_padding_chars_as_nulls.erase(decoded.end() - padding_count, '='), decoded.end());
+      auto decoded = std::string(decoded_with_padding_chars_as_nulls
+      return ;
   }
+
 
   inline std::string encode64(const std::string &val) {
       using namespace boost::archive::iterators;

--- a/xxhr/util.hpp
+++ b/xxhr/util.hpp
@@ -168,14 +168,12 @@ namespace util {
   inline std::string decode64(const std::string &val) {
       using namespace boost::archive::iterators;
       using It = transform_width<binary_from_base64<std::string::const_iterator>, 8, 6>;
-      // Remove padding and not all encoded \0  
       // See https://svn.boost.org/trac10/ticket/5629#comment:9
-      auto decoded_with_padding_chars_as_nulls = std::string(It(std::begin(val)), It(std::end(val)));
-      auto padding_count = std::count(val.end()-((std::min)(2, val.size())), val.end());
-      auto decoded = decoded_with_padding_chars_as_nulls.resize(decoded_with_padding_chars_as_nulls.size()-decoded_with_padding_chars_as_nulls);
-      decoded_with_padding_chars_as_nulls.erase(decoded.end() - padding_count, '='), decoded.end());
-      auto decoded = std::string(decoded_with_padding_chars_as_nulls
-      return ;
+      // Boost binary_from_base64 transforms '=' into '\0', they need to be removed to support binary data
+      auto decoded_with_zeroed_padding = std::string(It(std::begin(val)), It(std::end(val)));
+      auto padding_count = std::count(val.end() - std::min(std::size_t{2}, val.size()), val.end() , '=');
+      auto decoded = decoded_with_zeroed_padding.substr(0,decoded_with_zeroed_padding.size()-padding_count);
+      return decoded;
   }
 
 


### PR DESCRIPTION
We had an issue in the decode64 function that didn't correctly decode back to buffer with the exact same number of nullptr.