### PR TITLE
change cacerts path

### DIFF
--- a/.tipi/deps
+++ b/.tipi/deps
@@ -10,13 +10,13 @@
       "u": true
     }
 
-  , "nxxm/curl" : { "@" : ":eee4ae62ee24aec9c7f8948fd8670a5e80c2cf83"
+  , "nxxm/curl" : { "@" : ":6f0e7427d75d7b7462bb940c4ec8e46ee4214b25"
       , "opts" : "set(BUILD_CURL_TESTS OFF) \nset(BUILD_CURL_EXE ON) \nset(CMAKE_USE_OPENSSL ON) \nset(CMAKE_USE_LIBSSH2 OFF) \nset(BUILD_TESTING OFF)"
       , "u" : true
       , "packages" : ["CURL"]
       , "targets" : [ "CURL::libcurl" ]
       , "requires" : {
-        "nxxm/boringssl" : { "@" : ":64b173d5c7acb7e8e270997418685d9a00f0537b",
+        "nxxm/boringssl" : { "@" : ":358175c062c3a3964d4734df4b122e6af851def0",
             "u": true
             , "packages" : ["OpenSSL"]
             , "targets" : ["OpenSSL::SSL", "OpenSSL::Crypto"]

--- a/xxhr/impl/session-curl.hpp
+++ b/xxhr/impl/session-curl.hpp
@@ -616,6 +616,11 @@ void Session::Impl::prepareCommon() {
     curl_easy_setopt(curl_->handle, CURLOPT_CAINFO, "/etc/ssl/cert.pem");
 #endif
 
+    if (std::getenv("TIPI_CACERTS_PATH") != nullptr) {
+        std::string cacert_path = getenv("TIPI_CACERTS_PATH");
+        curl_easy_setopt(curl_->handle, CURLOPT_CAINFO,cacert_path.data());
+    }
+
 #if LIBCURL_VERSION_MAJOR >= 7
 #if LIBCURL_VERSION_MINOR >= 71
     // Fix loading certs from Windows cert store when using OpenSSL:

--- a/xxhr/impl/session-curl.hpp
+++ b/xxhr/impl/session-curl.hpp
@@ -643,7 +643,7 @@ void Session::Impl::prepareCommon() {
 
     // Enable so we are able to retrive certificate information:
     curl_easy_setopt(curl_->handle, CURLOPT_CERTINFO, 1L);
-    curl_easy_setopt(curl_->handle, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl_->handle, CURLOPT_NOSIGNAL, 0L);
 }
 
 Response Session::Impl::makeRequest() {

--- a/xxhr/impl/session-curl.hpp
+++ b/xxhr/impl/session-curl.hpp
@@ -616,8 +616,8 @@ void Session::Impl::prepareCommon() {
     curl_easy_setopt(curl_->handle, CURLOPT_CAINFO, "/etc/ssl/cert.pem");
 #endif
 
-    if (std::getenv("TIPI_CACERTS_PATH") != nullptr) {
-        std::string cacert_path = getenv("TIPI_CACERTS_PATH");
+    if (std::getenv("SSL_CERT_FILE") != nullptr) {
+        std::string cacert_path = getenv("SSL_CERT_FILE");
         curl_easy_setopt(curl_->handle, CURLOPT_CAINFO,cacert_path.data());
     }
 

--- a/xxhr/impl/session-curl.hpp
+++ b/xxhr/impl/session-curl.hpp
@@ -643,6 +643,7 @@ void Session::Impl::prepareCommon() {
 
     // Enable so we are able to retrive certificate information:
     curl_easy_setopt(curl_->handle, CURLOPT_CERTINFO, 1L);
+    curl_easy_setopt(curl_->handle, CURLOPT_NOSIGNAL, 1L);
 }
 
 Response Session::Impl::makeRequest() {

--- a/xxhr/impl/session-curl.hpp
+++ b/xxhr/impl/session-curl.hpp
@@ -643,7 +643,6 @@ void Session::Impl::prepareCommon() {
 
     // Enable so we are able to retrive certificate information:
     curl_easy_setopt(curl_->handle, CURLOPT_CERTINFO, 1L);
-    curl_easy_setopt(curl_->handle, CURLOPT_NOSIGNAL, 0L);
 }
 
 Response Session::Impl::makeRequest() {


### PR DESCRIPTION
The purpose of this pr is to allow curl to specify where it should look for its CACERTS. This makes it possible to support different linux distributions

Why the env variable SSL_CERT_FILE : https://stackoverflow.com/questions/38571099/how-can-i-set-the-certificates-in-curl
moreover emsdk respects this convention 

Comment in the curl code for the cli part
```
    /* Set the CA cert locations specified in the environment. For Windows if
     * no environment-specified filename is found then check for CA bundle
     * default filename curl-ca-bundle.crt in the user's PATH.
     *
     * If Schannel is the selected SSL backend then these locations are
     * ignored. We allow setting CA location for schannel only when explicitly
     * specified by the user via CURLOPT_CAINFO / --cacert.
     */
     
 ```