### PR TITLE
Qualify the call of getenv

### DIFF
--- a/xxhr/impl/session-curl.hpp
+++ b/xxhr/impl/session-curl.hpp
@@ -617,7 +617,7 @@ void Session::Impl::prepareCommon() {
 #endif
 
     if (std::getenv("SSL_CERT_FILE") != nullptr) {
-        std::string cacert_path = getenv("SSL_CERT_FILE");
+        std::string cacert_path = std::getenv("SSL_CERT_FILE");
         curl_easy_setopt(curl_->handle, CURLOPT_CAINFO,cacert_path.data());
     }
 


### PR DESCRIPTION
The purpose of this pr is to remove any ambiguity when calling getenv

Close: https://github.com/nxxm/xxhr/issues/20